### PR TITLE
Add finish url config switch

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>midtranspay</name>
 	<displayName><![CDATA[Midtrans Pay]]></displayName>
-	<version><![CDATA[2.5]]></version>
+	<version><![CDATA[2.6]]></version>
 	<description><![CDATA[Accept payments for your products via Midtrans payment gateway.]]></description>
 	<author><![CDATA[Midtrans]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/controllers/front/snappay.php
+++ b/controllers/front/snappay.php
@@ -28,6 +28,7 @@ class MidtransPaySnappayModuleFrontController extends ModuleFrontController
 		$moduleSuccessUrl = $this->context->link->getModuleLink('midtranspay','success');
 		$moduleFailureUrl = $this->context->link->getModuleLink('midtranspay','failure');
 		$isProduction = Configuration::get('MT_ENVIRONMENT') == 'production';
+		$isUsingMAPFinishUrl = Configuration::get('MT_ENABLED_MAP_FINISH_URL');
 		// error_log($moduleUrl); // debugan
 
 		$this->context->smarty->assign(array(
@@ -46,6 +47,7 @@ class MidtransPaySnappayModuleFrontController extends ModuleFrontController
 			'moduleUrl' => $moduleUrl,
 			'moduleSuccessUrl' => $moduleSuccessUrl,
 			'moduleFailureUrl' => $moduleFailureUrl,
+			'isUsingMAPFinishUrl' => $isUsingMAPFinishUrl,
 		));
 		if (version_compare(Configuration::get('PS_VERSION_DB'), '1.7') == -1)
 			$this->setTemplate('snappay.tpl');

--- a/js/midtrans_admin.js
+++ b/js/midtrans_admin.js
@@ -47,6 +47,7 @@
       '#MT_ENABLED_EXPIRY_on',
       '#MT_ENABLED_IGNORE_DENY_on',
       '#MT_ENABLED_REDIRECT_on',
+      '#MT_ENABLED_MAP_FINISH_URL_on',
     ];
     if ($("#MT_ENABLED_ADV_on").prop('checked')){
       changeViewAdvancedParents(advanceds,'show'); 

--- a/midtranspay.php
+++ b/midtranspay.php
@@ -131,6 +131,7 @@ class MidtransPay extends PaymentModule
 			'MT_LIST_CUSTOMVA',
 			'MT_ENABLED_IGNORE_DENY',
 			'MT_ENABLED_REDIRECT',
+			'MT_ENABLED_MAP_FINISH_URL',
 		);
 
 		$config = Configuration::getMultiple($this->config_keys);
@@ -233,6 +234,8 @@ class MidtransPay extends PaymentModule
 			Configuration::set('MT_ENABLED_IGNORE_DENY', 0);
 		if (!isset($config['MT_ENABLED_REDIRECT']))
 			Configuration::set('MT_ENABLED_REDIRECT', 0);
+		if (!isset($config['MT_ENABLED_MAP_FINISH_URL']))
+			Configuration::set('MT_ENABLED_MAP_FINISH_URL', 0);
 
 		parent::__construct();
 
@@ -323,6 +326,7 @@ class MidtransPay extends PaymentModule
 		Configuration::updateGlobalValue('MT_LIST_CUSTOMVA', "");
 		Configuration::updateGlobalValue('MT_ENABLED_IGNORE_DENY', 0);
 		Configuration::updateGlobalValue('MT_ENABLED_REDIRECT', 0);
+		Configuration::updateGlobalValue('MT_ENABLED_MAP_FINISH_URL', 0);
 
 		return true;
 	}
@@ -915,6 +919,28 @@ class MidtransPay extends PaymentModule
 								)
 							),
 						'class' => 'advanced-redirect'
+						//'class' => ''
+						),
+					// Enable use of Dashboard Finish URL instead of finish url hardcoded by module
+					array(						
+						'type' => (version_compare(Configuration::get('PS_VERSION_DB'), '1.6') == -1)?'radio':'switch',
+						'label' => 'Use Dashboard configured finish url instead of auto configured url?',
+						'name' => 'MT_ENABLED_MAP_FINISH_URL',
+						'required' => false,
+						'is_bool' => true,
+						'values' => array(
+							array(
+								'id' => 'map_finish_url_btn_yes',
+								'value' => 1,
+								'label' => 'Yes'
+								),
+							array(
+								'id' => 'map_finish_url_btn_no',
+								'value' => 0,
+								'label' => 'No'
+								)
+							),
+						'class' => 'advanced-mapfinishurl'
 						//'class' => ''
 						),
 					// Custom VA button

--- a/midtranspay.php
+++ b/midtranspay.php
@@ -72,7 +72,7 @@ class MidtransPay extends PaymentModule
 	{
 		$this->name = 'midtranspay';
 		$this->tab = 'payments_gateways';
-		$this->version = '2.5';
+		$this->version = '2.6';
 		$this->author = 'Midtrans';
 		$this->bootstrap = true;
 		

--- a/views/templates/front/snappay.tpl
+++ b/views/templates/front/snappay.tpl
@@ -128,7 +128,11 @@ var mainMidtransScript = function(event) {
 					onSuccess: function(result){
 						MixpanelTrackResult(SNAP_TOKEN, MERCHANT_ID, CMS_NAME, CMS_VERSION, PLUGIN_NAME, PLUGIN_VERSION, 'success', result);
 						console.log(result?result:'no result');
+{if $isUsingMAPFinishUrl}
+						window.location = result.finish_redirect_url;
+{else}
 						window.location = baseRedirectUrl+"&order_id="+result.order_id+"&status_code="+result.status_code+"&transaction_status="+result.transaction_status;
+{/if}
 					},
 			        onPending: function(result){
 						MixpanelTrackResult(SNAP_TOKEN, MERCHANT_ID, CMS_NAME, CMS_VERSION, PLUGIN_NAME, PLUGIN_VERSION, 'pending', result);

--- a/views/templates/front/snappay17.tpl
+++ b/views/templates/front/snappay17.tpl
@@ -130,7 +130,11 @@ var mainMidtransScript = function(event) {
 						MixpanelTrackResult(SNAP_TOKEN, MERCHANT_ID, CMS_NAME, CMS_VERSION, PLUGIN_NAME, PLUGIN_VERSION, 'success', result);
 						console.log(result?result:'no result');
 						payButton.innerHTML = 'Loading...';
+{if $isUsingMAPFinishUrl}
+						window.location = result.finish_redirect_url;
+{else}
 						window.location = baseRedirectUrl+"&order_id="+result.order_id+"&status_code="+result.status_code+"&transaction_status="+result.transaction_status;
+{/if}
 					},
 			        onPending: function(result){
 			        	MixpanelTrackResult(SNAP_TOKEN, MERCHANT_ID, CMS_NAME, CMS_VERSION, PLUGIN_NAME, PLUGIN_VERSION, 'pending', result);


### PR DESCRIPTION
- add config field to use finish url set on dashboard instead of module defined

### Background:
Some merchant might want to use finish url set on Dashboard (Snap Preference), previously finish url used is hardcoded inside Snap `onsuccess` callback JS function that redirect to module's Success controller

This PR allow merchant to enable usage of finish url set on Dashboard by utilizing Snap `result.finish_redirect_url` callback result.