### PR TITLE
Replace ceil with ps round

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>midtranspay</name>
 	<displayName><![CDATA[Midtrans Pay]]></displayName>
-	<version><![CDATA[2.7.1]]></version>
+	<version><![CDATA[2.7.2]]></version>
 	<description><![CDATA[Accept payments for your products via Midtrans payment gateway.]]></description>
 	<author><![CDATA[Midtrans]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/midtranspay.php
+++ b/midtranspay.php
@@ -1520,12 +1520,24 @@ class MidtransPay extends PaymentModule
 				$conversion_func = function($input) { return $input * intval(Configuration::get('MT_KURS')); };
 			}
 
-			foreach ($items as &$item) {						
-				$item['price'] = intval(ceil(call_user_func($conversion_func, $item['price'])));				
+			foreach ($items as &$item) {
+				$converted_item_price = call_user_func($conversion_func, $item['price']);
+				$item['price'] = 
+					intval(
+							Tools::ps_round(
+								$converted_item_price,
+								(Currency::getCurrencyInstance(intval($this->id_currency->decimals)) * _PS_PRICE_DISPLAY_PRECISION_)
+							)
+					);				
 			}
 		}else if($cart_currency->iso_code == 'IDR') {
 			foreach ($items as &$item) {						
-				$item['price'] = intval(ceil($item['price']));				
+				$item['price'] = intval(
+					Tools::ps_round(
+						$item['price'],
+						(Currency::getCurrencyInstance(intval($this->id_currency->decimals)) * _PS_PRICE_DISPLAY_PRECISION_)
+					)
+				);
 			}
 		}
 		

--- a/midtranspay.php
+++ b/midtranspay.php
@@ -1526,7 +1526,7 @@ class MidtransPay extends PaymentModule
 					intval(
 							Tools::ps_round(
 								$converted_item_price,
-								(Currency::getCurrencyInstance(intval($this->id_currency->decimals)) * _PS_PRICE_DISPLAY_PRECISION_)
+								(intval($this->context->currency->decimals) * _PS_PRICE_DISPLAY_PRECISION_)
 							)
 					);				
 			}
@@ -1535,7 +1535,7 @@ class MidtransPay extends PaymentModule
 				$item['price'] = intval(
 					Tools::ps_round(
 						$item['price'],
-						(Currency::getCurrencyInstance(intval($this->id_currency->decimals)) * _PS_PRICE_DISPLAY_PRECISION_)
+						(intval($this->context->currency->decimals) * _PS_PRICE_DISPLAY_PRECISION_)
 					)
 				);
 			}

--- a/midtranspay.php
+++ b/midtranspay.php
@@ -72,7 +72,7 @@ class MidtransPay extends PaymentModule
 	{
 		$this->name = 'midtranspay';
 		$this->tab = 'payments_gateways';
-		$this->version = '2.7.1';
+		$this->version = '2.7.2';
 		$this->author = 'Midtrans';
 		$this->bootstrap = true;
 		


### PR DESCRIPTION
Status: Still need consideration to merge this PR.

Gross amount now based on `$cart->getOrderTotal` instead of sum of
commodity items. Rounding happens for each items, previously result in
gross_amount having quite difference with PS total, due to accumulated
differences in each items. This aim to avoid that. New `Amount
Rounding` item introduced to keep the sum of items and cartTotal match.

possible side effect:
- in complex case, calculation might fails or result in validation
error (items & gross mismatch), which is transaction stopper
- `Amount Rounding` item can become too big and noticable
- merchant might not like `Amount Rounding` item

---------

PS have built in price rounding func, which should be used as best
practice instead of PHP default ceil. This is to ensure amount in
Midtrans match with amount on PS.

Side effect ps_round might round the number down (ceil will always
round up). PS might still display order amount without rounding, while
Midtrans might display the amount rounded down.
Some merchant might not accept that

Alternative to this changes:
Set currency in PS config to not have decimal number, so whatever round
func used is fine