### PR TITLE
fix missing ignore-deny check on deny notif handler

### DIFF
--- a/midtranspay.php
+++ b/midtranspay.php
@@ -1961,6 +1961,7 @@ class MidtransPay extends PaymentModule
 		     	$history->changeIdOrderState(Configuration::get('MT_PAYMENT_FAILURE_STATUS_MAP'), $order_id_notif);
 		       	echo 'Valid Cancel notification accepted.';
 		     }else if ($midtrans_notification->transaction_status == 'deny'){
+		     	if(Configuration::get('MT_ENABLED_IGNORE_DENY' == 1)){ exit; die('ignored'); }
 		     	$history->changeIdOrderState(Configuration::get('MT_PAYMENT_FAILURE_STATUS_MAP'), $order_id_notif);
 		       	echo 'Valid Deny notification accepted.';
 		     }else if ($midtrans_notification->transaction_status == 'expire'){


### PR DESCRIPTION
- fixing the issue of: upon receiving card deny notif it immediately change the CMS order status to failure, because lack of ignore-deny feature flag checking on the deny-notif handler